### PR TITLE
Reduce number of iterations

### DIFF
--- a/checks/microbenchmarks/mpi/osu/osu_tests.py
+++ b/checks/microbenchmarks/mpi/osu/osu_tests.py
@@ -37,6 +37,7 @@ class cscs_osu_pt2pt_check(cscs_osu_benchmarks):
     valid_systems = ['daint:gpu', 'daint:mc', 'dom:gpu', 'dom:mc',
                      'eiger:mc', 'pilatus:mc', 'arolla:cn', 'tsa:cn']
     valid_prog_environs = ['PrgEnv-gnu']
+    num_iters = 100
     benchmark_info = parameter([
         ('mpi.pt2pt.osu_bw', 'bandwidth'),
         ('mpi.pt2pt.osu_latency', 'latency')


### PR DESCRIPTION
OSU pt2pt default value of 1000 iterations takes quite long to run on some systems; 100 iterations should be sufficient.